### PR TITLE
style: ruby text should ignore white-space: pre-wrap

### DIFF
--- a/index.css
+++ b/index.css
@@ -220,6 +220,9 @@ a:hover { color: inherit; }
    border-top: 1px solid var(--outlinecolor);
 }
 
+/* white-space: pre-wrap messes up ruby alignment */
+ruby { white-space: normal; } 
+
 /* OOPS accidental(?) generic stuff */
 .username { margin: 0 0.4em; } /* pwusername, history, messageframeinfo, etc */
 .userdata { margin: 0 0.5em; }


### PR DESCRIPTION
![example of ruby rendering with/without white-space: pre-wrap](https://user-images.githubusercontent.com/12588017/132763920-2780885f-213f-4d27-9563-c1ee1120c816.png)
