### PR TITLE
Add nicknaming support

### DIFF
--- a/api.js
+++ b/api.js
@@ -669,10 +669,12 @@ var FrontendCoop = {
          return data;
       }
    },
-   CreateComment : function(rawtext, markup, avatar) {
+   CreateComment : function(rawtext, markup, avatar, nickname) {
       var meta = {"m":markup};
       if(avatar !== undefined)
          meta.a = avatar;
+      if(nickname !== undefined)
+         meta.n = nickname;
       return JSON.stringify(meta) + "\n" + rawtext;
    },
    TypeHasDiscussion : function(type) {

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ var options = {
       options: ["all", "none" ] },
    theme : {def: "light", u: 1, text: "Theme", options: [ "default", "dark", "blue",
       "contrast", "dark-contrast","oldschool" ]},
+   chatnickname : { def : "", u: 1, text : "Discussion Nickname (set blank to disable)" },
    datalog : { def: false, text : "Log received data objects" },
    drawlog : { def: false, text : "Log custom render data" },
    domlog : { def: false, text : "Log major DOM manipulation" },
@@ -954,7 +955,7 @@ function sendDiscussionMessage(message, markup, error)
    var currentDiscussion = getActiveDiscussionId();
    var sendData = {
       "parentId" : Number(currentDiscussion),
-      "content" : FrontendCoop.CreateComment(message, markup, getUserAvatar())
+      "content" : FrontendCoop.CreateComment(message, markup, getUserAvatar(), getNickname())
    };
 
    globals.api.Post("comment", sendData, undefined, error );
@@ -2181,6 +2182,11 @@ function getUsername() { return userusername.dataset.username; }
 function getUserAvatar() { return Number(navuseravatar.dataset.avatar); }
 function getIsSuper() { return website.getAttribute("data-issuper") == "true"; }
 
+function getNickname() {
+   var nickname = getLocalOption("chatnickname").substr(0, 50).replace(/\n/g, "  ");
+   return nickname != "" ? nickname : undefined;
+}
+
 function formError(form, error)
 {
    writeDom(() => form.appendChild(Templates.LoadHere("notifyelement_error",{message:error})));
@@ -2830,7 +2836,7 @@ function messageControllerEvent(event)
       commenteditinfo.textContent += "  Edited: " + (new Date(msg.editDate)).toLocaleString();
 
    var getEditorComment = () => 
-      FrontendCoop.CreateComment(commentedittext.value, commenteditformat.value, parsedcm.a);
+      FrontendCoop.CreateComment(commentedittext.value, commenteditformat.value, parsedcm.a, parsedcm.n);
 
    if(getUserId() != msg.createUserId && !getIsSuper())
    {

--- a/templates.js
+++ b/templates.js
@@ -13,7 +13,7 @@ var Templates = Object.create(null); with (Templates) (function($) { Object.assi
    _stdDate : (d) => (new Date(d)).toLocaleDateString(),
    _stdDateTime : (d) => (new Date(d)).toLocaleString(),
    _stdDateDiff : (d, short) => Utilities.TimeDiff(d, null, short),
-   _chatDisplayName : (parsed, real) => (typeof parsed.nickname == "string" ? `${parsed.nickname} (${real})` : real),
+   _chatDisplayName : (parsed, real) => (typeof parsed.nickname == "string" ? `${parsed.nickname.substr(0, 50).replace(/\n/g, "  ")} (${real})` : real),
    _displayRaw : (title, raw) => {
       rawmodaltitle.textContent = title;
       rawmodalraw.textContent = raw;


### PR DESCRIPTION
This pull request adds a textbox to the device settings that the user can use to set a nickname that will be used in discussions.
If left blank, no nickname will be used.
Nicknames are limited to 50 characters. Trying to use a longer nickname will result it in being cut off. (This is also the case on 12's frontend)